### PR TITLE
CAP-20 - Datasets: __getitem__ should be abstract and implemented in child classes

### DIFF
--- a/data/ClassicalMechanicsDataset.py
+++ b/data/ClassicalMechanicsDataset.py
@@ -18,9 +18,9 @@ class ClassicalMechanicsDataset(Dataset, metaclass=abc.ABCMeta):
         return len(self.data_files)
     
     
+    @abc.abstractmethod
     def __getitem__(self, idx):
-        data = np.load(self.data_files[idx])
-        return torch.FloatTensor(data[:, 0:3]), torch.FloatTensor(data[:, 3].reshape(-1,1))
+        pass
 
     
     @classmethod

--- a/data/OneBallFreeFallThreeFramesDataset.py
+++ b/data/OneBallFreeFallThreeFramesDataset.py
@@ -1,4 +1,5 @@
 from glob import glob
+import torch
 import numpy as np
 import re
 import os
@@ -6,6 +7,11 @@ import phyre
 from .ClassicalMechanicsDataset import ClassicalMechanicsDataset
 
 class OneBallFreeFallThreeFramesDataset(ClassicalMechanicsDataset):
+    def __getitem__(self, idx):
+        data = np.load(self.data_files[idx])
+        return torch.FloatTensor(data[:, 0:3]), torch.FloatTensor(data[:, 3].reshape(-1,1))
+
+
     def generate_data(self):
         # Choosing a setup where only one ball is needed
         eval_setup = 'ball_cross_template'


### PR DESCRIPTION
Made __getitem__ abstract in the base dataset class and moved the existing implementation to the 1D dataset class.